### PR TITLE
Revert "[FIX] IPOA-698 Twitter images in footer are links an oddly under...

### DIFF
--- a/Resources/Private/Twitter/Templates/Tweet/List.html
+++ b/Resources/Private/Twitter/Templates/Tweet/List.html
@@ -35,7 +35,8 @@
 								<f:if condition="{iterator.index} < 2">
 									<f:then>
 										<p><span class="text--small">
-											<img src="{tweet.user.profile_image_url}" alt="{tweet.user.name}"/>
+											<a href="https://twitter.com/{tweet.user.screen_name}">
+												<img src="{tweet.user.profile_image_url}" alt="{tweet.user.name}"/></a>
 											<a href="https://twitter.com/{tweet.user.screen_name}">{tweet.user.name}</a>
 											(<tw:link.tweet class="cwtw-TweetMeta-timestamp" tweet="{tweet}">
 												<f:format.date format="H:m - d.m.Y">{tweet.created_at}</f:format.date>


### PR DESCRIPTION
Reverts subugoe/typo3-tmpl_ipoa#171

With this fix the images are not linked anymore. But they should be.